### PR TITLE
Add backend Dockerfile skeleton 

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+.git

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+# Intial Docker image for the backend service.
+# This will be update when he FastAPI backend implementation is added.
+
+FROM python:3.12-slim
+
+WORKDIR / app
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "-m", "http.server", "8000"]


### PR DESCRIPTION
Adds on initial Dockerfile for the backend service.

Included:
- Python 3.12 slim base image
- backend working directory
- exposed port 8000
- temporary start command for skeleton backend

Verified locally:
- Docker image builds successfully
- Container runs on localhost:8000