### PR TITLE
Add docker compose setup for backend and frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+# Runs backend and frontend services together
+
+services:
+ backend:
+  build: ./backend
+  ports:
+   - "8000:8000"
+
+ frontend:
+  build: ./frontend
+  ports:
+   - "3000:3000"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+
+COPY . /usr/share/nginx/html


### PR DESCRIPTION
Adds docker-compose setup to run backend and frontend services together.

Included:
- backend service using Dockerfile
- frontend placeholder service
- port mappings for both services

Verified locally:
- docker compose build runs successfully